### PR TITLE
Option to add space between flag icon and country name.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -160,10 +160,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -213,5 +213,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.12.0"

--- a/lib/src/fl_country_code_picker.dart
+++ b/lib/src/fl_country_code_picker.dart
@@ -22,6 +22,7 @@ class FlCountryCodePicker {
     this.favoritesIcon = kFavoritesIcon,
     this.countryTextStyle,
     this.dialCodeTextStyle,
+    this.horizontalTitleGap
   });
 
   /// Convinience getter for all of the available country codes.
@@ -78,6 +79,8 @@ class FlCountryCodePicker {
   /// Defaults to `true`.
   /// {@endtemplate}
   final bool showDialCode;
+
+  final double? horizontalTitleGap;
 
   /// {@template item_builder}
   ///
@@ -174,6 +177,7 @@ class FlCountryCodePicker {
         title: title,
         localize: localize,
         favorites: favorites,
+        horizontalTitleGap: horizontalTitleGap,
         showDialCode: showDialCode,
         favoritesIcon: favoritesIcon,
         showSearchBar: showSearchBar,

--- a/lib/src/widgets/country_code_picker_modal.dart
+++ b/lib/src/widgets/country_code_picker_modal.dart
@@ -19,6 +19,7 @@ class CountryCodePickerModal extends StatefulWidget {
     required this.showDialCode,
     required this.showFavoritesIcon,
     this.title,
+    this.horizontalTitleGap,
     this.focusedCountry,
     this.searchBarDecoration,
     this.favorites = const [],
@@ -42,6 +43,8 @@ class CountryCodePickerModal extends StatefulWidget {
 
   /// {@macro show_favorites_icon}
   final bool showFavoritesIcon;
+
+  final double? horizontalTitleGap;
 
   /// {@macro show_dial_code}
   final bool showDialCode;
@@ -163,6 +166,7 @@ class _CountryCodePickerModalState extends State<CountryCodePickerModal> {
               return ListTile(
                 onTap: () => Navigator.pop(context, code),
                 leading: code.flagImage(),
+                horizontalTitleGap: widget.horizontalTitleGap?? 40,
                 title: Text(
                   name,
                   style: widget.countryTextStyle,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -329,10 +329,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -454,5 +454,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.12.0"


### PR DESCRIPTION
Added `horizontalTitleGap` to facilitate space between flag icon and country name.